### PR TITLE
typo: options.selectabl -> options.selectable

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,7 +115,7 @@ Dropdown.prototype.focus = function(slug){
 
   classes(this.current[0]).add('current');
 
-  if (this.options.selectabl && this.options.menu) {
+  if (this.options.selectable && this.options.menu) {
     this.ref.html(o(this.items[slug]).find('a').html());
   }
   return this;


### PR DESCRIPTION
This borks up the 'selectable' behaviour as shown:

Selecting a Fruit
![http://i.imgur.com/4m7u6.png](http://i.imgur.com/4m7u6.png)

Currently ends up with no item visibly "selected":
![http://i.imgur.com/Qmatr.png](http://i.imgur.com/Qmatr.png)

Instead of displaying the item:
![http://i.imgur.com/uAVsk.png](http://i.imgur.com/uAVsk.png)
