### PR TITLE
Emit focus event on focus.

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ Dropdown.prototype.focus = function(slug){
 
   if (this.options.selectable && this.options.menu) {
     this.ref.html(o(this.items[slug]).find('a').html());
+    this.emit('focus', slug);
   }
-  this.emit('focus', slug);
   return this;
 };


### PR DESCRIPTION
This allows you to trigger actions when items are either clicked (selected) or `focus()`ed programmatically.

Not ideal, `select` and `focus` should probably be the same event, and you should probably be able to programatically select items in a `menu`, but that would require some rewiring of the two components and this is a simple, easy fix.
