### PR TITLE
Fixed the moveTo() call to include 'px'

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,7 +131,7 @@ Dropdown.prototype.onclick = function(ev){
     x = ev.pageX, y = ev.pageY;
   }
 
-  this.moveTo(x, y);
+  this.moveTo(x + 'px', y + 'px');
   this.coor = { x: x, y: y };
   this.show();
 };


### PR DESCRIPTION
The `Menu.moveTo` call looks like this:

```
Menu.prototype.moveTo = function(x, y){
  this.el.style.top = y;
  this.el.style.left = x;
  return this;
};
```
